### PR TITLE
if no new boots, exit gracefully

### DIFF
--- a/zappos.py
+++ b/zappos.py
@@ -207,7 +207,7 @@ if __name__ == "__main__":
         print(res)
     else:
         # Do nothing - close out
-        sys.exit("Not enough new boots.. Packing up and going home.")
+        sys.exit(0)
 
 
     print("\nDone.", flush=True)


### PR DESCRIPTION
The job doesn't exit gracefully when it doesn't find any new boots. Kubernetes thinks the container is crashing and restarts it. It will do this 6 times before marking the job as failed.

Adding a graceful exit.